### PR TITLE
Remove "-cells" suffix from cellZones names

### DIFF
--- a/runtimeWrite.cxx
+++ b/runtimeWrite.cxx
@@ -1130,8 +1130,7 @@ public:
         if (VcCells & vc.tid) {
             // build cell set
             cellSetFile_ = new FoamCellSetFile;
-            cellSetFile_->open(uniqueSafeFileName(vc.name, usedNames,
-                "-cells"));
+            cellSetFile_->open(uniqueSafeFileName(vc.name, usedNames));
         }
         pwpCwdPop();
     }


### PR DESCRIPTION
Appending the extra characters to the cellZones names gets in the way of automating other pre-processing steps in OpenFOAM. My feeling is that the primary use of Pointwise volume conditions is to assign names to regions of cells (cellSets and cellZones) and rarely the other types, therefore leave the user specified names as-is for cellZones and cellSets.

-Chris